### PR TITLE
Update Dependabot configuration for weekly updates

### DIFF
--- a/.github/dependabot.yml
+++ b/.github/dependabot.yml
@@ -8,7 +8,9 @@ updates:
   - package-ecosystem: "npm" # See documentation for possible values
     directory: "/" # Location of package manifests
     schedule:
-      interval: "daily"
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:00"
     groups:
       storybook:
         patterns:
@@ -30,3 +32,9 @@ updates:
       ngrx:
         patterns:
             - "@ngrx/*"
+  - package-ecosystem: "github-actions"
+    directory: "/"
+    schedule:
+      interval: "weekly"
+      day: "tuesday"
+      time: "03:00"


### PR DESCRIPTION
Change Dependabot schedule to weekly for npm and add GitHub Actions updates.